### PR TITLE
Agent queue start

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -156,7 +156,7 @@ To work this strips out the two images from the pdfstream data stream.
 Running List of Gripes/Complaints/Bugs/Suggested Improvements
 -------------------------------------------------------------
 - The way the agent inserts documents into db accesses too many private attributes.
-This is either the wrong way to do things, or the right way doesn't exist yet.
+    - This is either the wrong way to do things, or the right way doesn't exist yet.
 - Security of the queue. Agents need to be able to start the queue, but this creates a safety issue for beamline emergencies.
     - Our current strategy is that the beamline scientist controls the state of the queue-server environment.
     - The agents are then allowed to try and start/stop the queue.


### PR DESCRIPTION
This gives the agents the ability to start the queue, only if the queue has exactly 1 item, the environment is open, and the manager isn't already doing something. 

@dmgav Are these sufficient conditions to make sure I'm not starting an already running queue, nor starting in a closed environment? Just want to preempt an agent crashing due to an anticipatable Exception here. 