### PR TITLE
Enhanced ask metadata

### DIFF
--- a/mmm_experiments/agents/base.py
+++ b/mmm_experiments/agents/base.py
@@ -301,9 +301,11 @@ class Agent(ABC):
 
         """
         doc, next_points = self.ask(batch_size)
+        doc.setdefault("uid", str(uuid.uuid4()))
         for point in next_points:
             kwargs = self.measurement_plan_kwargs(point)
             kwargs["md"].update(self.default_plan_md)
+            kwargs["md"]["agent_ask_uid"] = doc["uid"]
             plan = BPlan(
                 self.measurement_plan_name,
                 *self.measurement_plan_args(point),

--- a/mmm_experiments/agents/base.py
+++ b/mmm_experiments/agents/base.py
@@ -310,7 +310,7 @@ class Agent(ABC):
                 **kwargs,
             )
             r = self.re_manager.item_add(plan, pos=self.queue_add_position)
-            logging.info(f"Sent http-server request for point {point}\n." f"Received reponse: {r}")
+            logging.debug(f"Sent http-server request for point {point}\n." f"Received reponse: {r}")
         return doc
 
     def _check_queue_and_start(self):

--- a/mmm_experiments/agents/base.py
+++ b/mmm_experiments/agents/base.py
@@ -303,6 +303,8 @@ class Agent(ABC):
             )
             r = self.re_manager.item_add(plan, pos=self.queue_add_position)
             logging.info(f"Sent http-server request for point {point}\n." f"Received reponse: {r}")
+        doc["exp_catalog"] = doc.get("exp_catalog", self.exp_catalog)
+        doc["agent_catalog"] = doc.get("agent_catalog", self.agent_catalog)
         return doc
 
     def _check_queue_and_start(self):

--- a/mmm_experiments/agents/bmm.py
+++ b/mmm_experiments/agents/bmm.py
@@ -114,6 +114,7 @@ class BMMAgent(Agent, ABC):
             steps="10 2 0.3 0.05k",
             times="0.5 0.5 0.5 0.5",
             snapshots=False,
+            md={"relative_position": point},
         )
 
     def trigger_condition(self, uid) -> bool:

--- a/mmm_experiments/agents/joint.py
+++ b/mmm_experiments/agents/joint.py
@@ -100,6 +100,7 @@ class MonarchPDFSubjectBMM(GeometricResolutionMixin, MonarchSubjectBase, PDFAgen
         kwargs = BMMAgent.measurement_plan_kwargs(self, point)
         kwargs.setdefault("md", {})
         kwargs["md"]["agent"] = f"MonarchPDFSubjectBMM_{self.model_method}"
+        kwargs["md"].update(self.default_plan_md)
         return kwargs
 
     def get_wafer_background(self):
@@ -189,7 +190,9 @@ class MonarchBMMSubjectPDF(GeometricResolutionMixin, MonarchSubjectBase, BMMAgen
         return ["Grid_X", point + self.subject_origin, 30]
 
     def subject_plan_kwargs(self, point) -> dict:
-        return {"sample_number": 17}
+        md = self.default_plan_md
+        md["relative_position"] = point
+        return {"sample_number": 17, "md": md}
 
     def measurement_plan_kwargs(self, point) -> dict:
         kwargs = super().measurement_plan_kwargs(point)

--- a/mmm_experiments/agents/pdf.py
+++ b/mmm_experiments/agents/pdf.py
@@ -82,7 +82,8 @@ class PDFAgent(Agent, ABC):
         return ["Grid_X", x_position + self.measurement_origin, 30]
 
     def measurement_plan_kwargs(self, point) -> dict:
-        return {"sample_number": 16}
+        md = {"relative_position": point}
+        return {"sample_number": 16, "md": md}
 
     @staticmethod
     def unpack_run(run: BlueskyRun):


### PR DESCRIPTION
Put rich metadata into the plans by default to explain what plan relates to what `ask`, and some other relative request from BLS. This should be referential for development on Adjudicators. 