### PR TITLE
Add 0MQ to kafka bridge as a service for PDF

### DIFF
--- a/mmm_experiments/zmq-bridge.service
+++ b/mmm_experiments/zmq-bridge.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=0MQ bridge being used for MMM experiments
+
+[Service]
+User=xf28id1
+Group=xf28id1
+Environment="PATH=/home/xf28id1/project-mmm/mmm-experiments/venv/bin/:$PATH"
+ExecStart=/home/xf28id1/project-mmm/mmm-experiments/venv/bin/python3 -m mmm_experiments.data.zmq_bridge
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
It's the systemd service file that needs to be put into the relevant directory. 

Feel free to move the file if you would rather it be somewhere else. 